### PR TITLE
Start the created Thread-objects

### DIFF
--- a/src/com/qozix/tileview/tiles/TileCache.java
+++ b/src/com/qozix/tileview/tiles/TileCache.java
@@ -65,7 +65,7 @@ public class TileCache {
 					
 				}
 			}
-		});
+		}).start();
 	}
 
 	public void addBitmap( String key, Bitmap bitmap ) {
@@ -94,7 +94,7 @@ public class TileCache {
 					
 				}
 			}
-		});		
+		}).start();		
 	}
 	
 	public void clear() {
@@ -108,7 +108,7 @@ public class TileCache {
 					
 				}
 			}
-		});		
+		}).start();		
 	}
 	
 	private void addBitmapToMemoryCache( String key, Bitmap bitmap ) {


### PR DESCRIPTION
In the TileCache, a few Thread's are created, but they are never started.
And so the LruDiskCache is actually not working at all! This PR should fix that issue.
