### PR TITLE
Propogate no clip properties to "clip" layout.

### DIFF
--- a/src/com/qozix/layouts/ZoomPanLayout.java
+++ b/src/com/qozix/layouts/ZoomPanLayout.java
@@ -503,6 +503,18 @@ public class ZoomPanLayout extends ViewGroup {
 		startSmoothScaleTo( destination, duration );
 	}
 
+	@Override
+	public void setClipChildren(boolean clipChildren) {
+		super.setClipChildren(clipChildren);
+		clip.setClipChildren(clipChildren);
+	}
+
+	@Override
+	public void setClipToPadding(boolean clipToPadding) {
+		super.setClipToPadding(clipToPadding);
+		clip.setClipToPadding(clipToPadding);
+	}
+
 	//------------------------------------------------------------------------------------
 	// PRIVATE/PROTECTED
 	//------------------------------------------------------------------------------------


### PR DESCRIPTION
Previously if you had a marker that extended beyond the clip region (but you wanted it to show, e.g. a flag) you might try setting `clipChildren` or `clipToPadding` to false on the TileView. However, this actually doesn't work since the clip variable isn't propagated to the correct layout.

This PR fixes that bug.
