### PR TITLE
Add removeAllMarkers to MarkerManager

### DIFF
--- a/tileview/src/main/java/com/qozix/tileview/TileView.java
+++ b/tileview/src/main/java/com/qozix/tileview/TileView.java
@@ -541,6 +541,11 @@ public class TileView extends ZoomPanLayout {
 		markerManager.removeMarker( view );
 	}
 
+    /**
+     * Removes all markers from TileView's view tree
+     */
+    public void removeAllMarkers(){ markerManager.removeAllMarkers();}
+
 	/**
 	 * Moves an existing marker to another position.
 	 * @param view The marker View to be repositioned.

--- a/tileview/src/main/java/com/qozix/tileview/markers/MarkerManager.java
+++ b/tileview/src/main/java/com/qozix/tileview/markers/MarkerManager.java
@@ -71,6 +71,18 @@ public class MarkerManager extends TranslationLayout implements DetailLevelEvent
 		markerMap.remove( v );
 	}
 
+    public void removeAllMarkers(){
+
+        Iterator<View> iteratorViews = markerMap.keySet().iterator();
+
+        while(iteratorViews.hasNext()){
+            View v = iteratorViews.next();
+            removeView(v);
+            iteratorViews.remove();
+        }
+
+    }
+
 	public void addMarkerEventListener( MarkerEventListener listener ) {
 		listeners.add( listener );
 	}


### PR DESCRIPTION
There was no option to remove all markers from the TileView's tree although there were
methods to remove individual markers, so references to the markers were stored thus making a
removeAllMarkers method not difficult and didn't need deep changes to the core code.