### PR TITLE
Remove AndroidManifest.xml defaults

### DIFF
--- a/tileview/src/main/AndroidManifest.xml
+++ b/tileview/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.qozix.tileview">
 
-  <application android:allowBackup="true"
-               android:supportsRtl="true"
-    >
-
-  </application>
+  <application />
 
 </manifest>


### PR DESCRIPTION
These defaults might clash with a including project and cause lint errors unless the API client include `tools:replace="allowBackup,supportsRtl"` within their AndroidManifest.xml