### PR TITLE
Fix issues #258, #252 and #259

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ###Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:2.1.0'
+compile 'com.qozix:tileview:2.0.10'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.
@@ -47,7 +47,7 @@ A demo application, built in Android Studio, is available in the `demo` folder o
 at the 2nd column from left and 3rd row from top.
 1. Create a new application with a single activity ('Main').
 1. Save the image tiles to your `assets` directory.
-1. Add `compile 'com.qozix:tileview:2.1.0'` to your gradle dependencies.
+1. Add `compile 'com.qozix:tileview:2.0.10'` to your gradle dependencies.
 1. In the Main Activity, use this for `onCreate`:
 ```
 @Override

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ###Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:2.0.9'
+compile 'com.qozix:tileview:2.1.0'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.
@@ -47,7 +47,7 @@ A demo application, built in Android Studio, is available in the `demo` folder o
 at the 2nd column from left and 3rd row from top.
 1. Create a new application with a single activity ('Main').
 1. Save the image tiles to your `assets` directory.
-1. Add `compile 'com.qozix:tileview:2.0.9'` to your gradle dependencies.
+1. Add `compile 'com.qozix:tileview:2.1.0'` to your gradle dependencies.
 1. In the Main Activity, use this for `onCreate`:
 ```
 @Override

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 11
         targetSdkVersion 22
         versionCode 27
-        versionName "2.0.9"
+        versionName "2.1.0"
     }
     buildTypes {
         release {

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -7,7 +7,7 @@ android {
         minSdkVersion 11
         targetSdkVersion 22
         versionCode 27
-        versionName "2.1.0"
+        versionName "2.0.10"
     }
     buildTypes {
         release {

--- a/tileview/src/main/java/com/qozix/tileview/TileView.java
+++ b/tileview/src/main/java/com/qozix/tileview/TileView.java
@@ -772,7 +772,9 @@ public class TileView extends ZoomPanLayout implements
 
   @Override
   public void onZoomBegin( float scale, Origination origin ) {
-    mDetailLevelManager.lockDetailLevel();
+    if( !Origination.DOUBLE_TAP.equals( origin ) ) {
+      mDetailLevelManager.lockDetailLevel();
+    }
     mDetailLevelManager.setScale( scale );
   }
 
@@ -790,7 +792,6 @@ public class TileView extends ZoomPanLayout implements
 
   @Override
   public void onDetailLevelChanged( DetailLevel detailLevel ) {
-    requestRender();
     mTileCanvasViewGroup.updateTileSet( detailLevel );
   }
 

--- a/tileview/src/main/java/com/qozix/tileview/detail/DetailLevel.java
+++ b/tileview/src/main/java/com/qozix/tileview/detail/DetailLevel.java
@@ -57,7 +57,6 @@ public class DetailLevel implements Comparable<DetailLevel> {
    *
    * @return List of Tile instances describing the currently visible viewport.
    */
-
   public LinkedList<Tile> getVisibleTilesFromLastViewportComputation() {
     if( mLastStateSnapshot == null ) {
       throw new StateNotComputedException();

--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
@@ -31,6 +31,7 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
   private TileRenderTask mLastRunTileRenderTask;
 
   private DetailLevel mDetailLevelToRender;
+  private DetailLevel mLastRequestedDetailLevel;
   private DetailLevel mLastRenderedDetailLevel;
   private TileCanvasView mCurrentTileCanvasView;
 
@@ -144,10 +145,10 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
     if( mDetailLevelToRender == null ) {
       return;
     }
-    if( mDetailLevelToRender.equals( mLastRenderedDetailLevel ) ) {
+    if( mDetailLevelToRender.equals( mLastRequestedDetailLevel ) ) {
       return;
     }
-    mLastRenderedDetailLevel = mDetailLevelToRender;
+    mLastRequestedDetailLevel = mDetailLevelToRender;
     mCurrentTileCanvasView = getCurrentTileCanvasView();
     mCurrentTileCanvasView.bringToFront();
     cancelRender();
@@ -199,7 +200,7 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
 
   private void beginRenderTask() {
     boolean changed = mDetailLevelToRender.computeCurrentState();
-    if( !changed ) {
+    if( !changed && mDetailLevelToRender.equals( mLastRenderedDetailLevel ) ) {
       return;
     }
     mTilesVisible = mDetailLevelToRender.getVisibleTilesFromLastViewportComputation();
@@ -248,8 +249,7 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
     if( mTileRenderListener != null ) {
       mTileRenderListener.onRenderComplete();
     }
-    invalidate();
-    requestRender();
+    mLastRenderedDetailLevel = mDetailLevelToRender;
   }
 
   LinkedList<Tile> getRenderList() {


### PR DESCRIPTION
Since the last PR i solved #252 and #259.

Solving #259 was not easy. While i was doing that i stumbled on the real culprit for #252 : in `TileCanvasViewGroup.beginRenderTask()`, after calling `mDetailLevelToRender.computeCurrentState()`, the method returned without starting a rendering task, because `computeCurrentState()` returned `false` in a situation where a render is really needed. E.g after a double tap from the maximum scale.

I tested all this in various situations, it works perfectly and it definitely improved the situation described in #259. 