### PR TITLE
Multithread tile rendering 2

### DIFF
--- a/demo/src/main/java/tileview/demo/provider/BitmapHttpProvider.java
+++ b/demo/src/main/java/tileview/demo/provider/BitmapHttpProvider.java
@@ -3,7 +3,6 @@ package tileview.demo.provider;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.util.Log;
 
 import com.qozix.tileview.graphics.BitmapProvider;
 import com.qozix.tileview.tiles.Tile;
@@ -41,10 +40,10 @@ public class BitmapHttpProvider implements BitmapProvider {
             }
           }
         } catch ( IOException e ) {
-          Log.e( TAG, "IOException " + fileName, e );
+//          Log.e( TAG, "IOException " + fileName, e );
         }
       } catch ( MalformedURLException e1 ) {
-        Log.e( TAG, "MalformedURLException " + fileName, e1 );
+//        Log.e( TAG, "MalformedURLException " + fileName, e1 );
       }
     }
     return null;

--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
@@ -169,6 +169,7 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
       tile.destroy( mShouldRecycleBitmaps );
     }
     mTilesAlreadyRendered.clear();
+    mPoolExecutor.cancel();
   }
 
   private float getCurrentDetailLevelScale() {
@@ -284,6 +285,7 @@ public class TileCanvasViewGroup extends ScalingLayout implements TileCanvasView
   }
 
   public void destroy(){
+    mPoolExecutor.shutDown();
     clear();
     for( TileCanvasView tileGroup : mTileCanvasViewHashMap.values() ) {
       tileGroup.clearTiles( mShouldRecycleBitmaps );

--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileRenderPoolExecutor.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileRenderPoolExecutor.java
@@ -31,7 +31,7 @@ public class TileRenderPoolExecutor {
 
   public void cancel() {
     synchronized ( this ) {
-      if( ( mViewGroup != null && mViewGroup.get() != null ) && ( mQueue.size()>0 || mExecutor.getActiveCount() > 0 ) ){
+      if( isViewGroupValid() && ( mQueue.size()>0 || mExecutor.getActiveCount() > 0 ) ){
         mViewGroup.get().onRenderTaskCancelled();
       }
 
@@ -61,6 +61,10 @@ public class TileRenderPoolExecutor {
         mFutureList.add( mExecutor.submit( new TileRenderRunnable( viewGroup, tile ) ) );
       }
     }
+  }
+
+  private boolean isViewGroupValid(){
+    return mViewGroup != null && mViewGroup.get() != null;
   }
 
   static class TileRenderRunnable implements Runnable {
@@ -107,7 +111,7 @@ public class TileRenderPoolExecutor {
     protected void afterExecute( Runnable r, Throwable t ) {
       super.afterExecute( r, t );
       //getActiveCount() == 1 to make sure it is going to execute only for the last thread to run
-      if( mQueue != null && mQueue.size() == 0 && mViewGroup != null && mViewGroup.get() != null && getActiveCount() == 1 ) {
+      if( mQueue != null && mQueue.size() == 0 && isViewGroupValid() && getActiveCount() == 1 ) {
         mViewGroup.get().onRenderTaskPostExecute();
         mFutureList.clear();
       }

--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileRenderPoolExecutor.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileRenderPoolExecutor.java
@@ -1,5 +1,7 @@
 package com.qozix.tileview.tiles;
 
+import android.os.Process;
+
 import java.lang.ref.WeakReference;
 import java.util.LinkedList;
 import java.util.concurrent.BlockingQueue;
@@ -7,7 +9,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import android.os.Process;
 
 public class TileRenderPoolExecutor {
   // Sets the amount of time an idle thread will wait for a task before terminating
@@ -30,6 +31,10 @@ public class TileRenderPoolExecutor {
 
   public void cancel() {
     synchronized ( this ) {
+      if( ( mViewGroup != null && mViewGroup.get() != null ) && ( mQueue.size()>0 || mExecutor.getActiveCount() > 0 ) ){
+        mViewGroup.get().onRenderTaskCancelled();
+      }
+
       for ( Future f : mFutureList ) {
         if( !f.isDone() ){
           f.cancel( true );
@@ -40,11 +45,19 @@ public class TileRenderPoolExecutor {
     }
   }
 
+  public void shutDown(){
+    cancel();
+    mExecutor.shutdownNow();
+  }
+
   public void queue( TileCanvasViewGroup viewGroup, LinkedList<Tile> tiles ) {
-    if( tiles != null && tiles.size() > 0) {
+    if( tiles != null && tiles.size() > 0 ) {
       mViewGroup = new WeakReference<>( viewGroup );
       viewGroup.onRenderTaskPreExecute();
       for ( Tile tile : tiles ){
+        if( mExecutor.isShutdown() || mExecutor.isTerminating() || mExecutor.isTerminated() ){
+          return;
+        }
         mFutureList.add( mExecutor.submit( new TileRenderRunnable( viewGroup, tile ) ) );
       }
     }
@@ -54,33 +67,32 @@ public class TileRenderPoolExecutor {
     private final WeakReference<TileCanvasViewGroup> mTileCanvasViewGroup;
     private final WeakReference<Tile> mTile;
 
-    public TileRenderRunnable( TileCanvasViewGroup viewGroup, Tile tile) {
+    public TileRenderRunnable( TileCanvasViewGroup viewGroup, Tile tile ) {
       mTileCanvasViewGroup = new WeakReference<>( viewGroup );
       mTile = new WeakReference<>( tile );
     }
 
     @Override
     public void run() {
-      Process.setThreadPriority( Process.THREAD_PRIORITY_BACKGROUND );
+      Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND );
       final Thread thread = Thread.currentThread();
 
-      TileCanvasViewGroup tileCanvasViewGroup = mTileCanvasViewGroup.get();
+      TileCanvasViewGroup viewGroup = mTileCanvasViewGroup.get();
       Tile tile = mTile.get();
 
-      if( tileCanvasViewGroup != null ){
+      if( viewGroup != null ){
         if( thread.isInterrupted() ){
-          tileCanvasViewGroup.onRenderTaskCancelled();
           return;
         }
 
-        if( !tileCanvasViewGroup.getRenderIsCancelled() && tile != null ){
-          tileCanvasViewGroup.generateTileBitmap( tile );
-          if ( thread.isInterrupted() ){
-            tileCanvasViewGroup.onRenderTaskCancelled();
+        if( !viewGroup.getRenderIsCancelled() && tile != null ){
+          viewGroup.generateTileBitmap(tile);
+
+          if( tile.getBitmap() == null || thread.isInterrupted() || viewGroup.getRenderIsCancelled() ){
             return;
           }
 
-          tileCanvasViewGroup.addTileToCurrentTileCanvasView( tile );
+          viewGroup.addTileToCurrentTileCanvasView( tile );
         }
       }
     }
@@ -94,8 +106,8 @@ public class TileRenderPoolExecutor {
     @Override
     protected void afterExecute( Runnable r, Throwable t ) {
       super.afterExecute( r, t );
-//      getActiveCount() == 1 to make sure it is going to execute only for the last thread to run
-      if( mQueue != null && mQueue.size() == 0 && mViewGroup != null && mViewGroup.get() != null && getActiveCount() == 1) {
+      //getActiveCount() == 1 to make sure it is going to execute only for the last thread to run
+      if( mQueue != null && mQueue.size() == 0 && mViewGroup != null && mViewGroup.get() != null && getActiveCount() == 1 ) {
         mViewGroup.get().onRenderTaskPostExecute();
         mFutureList.clear();
       }


### PR DESCRIPTION
Improvements of this PR were discussed on 
https://github.com/moagrius/TileView/issues/250

Also fix issue found out on discussion 
https://github.com/moagrius/TileView/pull/263

Do not call `addTileToCurrentTileCanvasView`if bitmap was not rendered. Proper calling `onRenderTaskCancelled` whenever the whole rendering is canceled. Also added a `shutdown` method in `TileRenderPoolExecutor` to avoid receiving more tiles to render.