### PR TITLE
Add the ability to use a custom DetailLevelManager (#293).

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ###Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:2.1.4'
+compile 'com.qozix:tileview:2.1.5'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.
@@ -54,7 +54,7 @@ A demo application, built in Android Studio, is available in the `demo` folder o
 at the 2nd column from left and 3rd row from top.
 1. Create a new application with a single activity ('Main').
 1. Save the image tiles to your `assets` directory.
-1. Add `compile 'com.qozix:tileview:2.1.4'` to your gradle dependencies.
+1. Add `compile 'com.qozix:tileview:2.1.5'` to your gradle dependencies.
 1. In the Main Activity, use this for `onCreate`:
 ```
 @Override

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 22
-        versionCode 29
-        versionName "2.1.4"
+        versionCode 30
+        versionName "2.1.5"
     }
     buildTypes {
         release {

--- a/tileview/src/main/java/com/qozix/tileview/TileView.java
+++ b/tileview/src/main/java/com/qozix/tileview/TileView.java
@@ -716,6 +716,30 @@ public class TileView extends ZoomPanLayout implements
     mTileCanvasViewGroup.setRenderBuffer( buffer );
   }
 
+  /**
+   * Allows the use of a custom {@link DetailLevelManager}.
+   * <p>
+   * For example, to change the logic of {@link DetailLevel} choice for a given scale, you
+   * declare your own {@code DetailLevelMangerCustom} that extends {@link DetailLevelManager} :
+   * <pre>{@code
+   * private class DetailLevelManagerCustom extends DetailLevelManager{
+   *  @literal @Override
+   *   public DetailLevel getDetailLevelForScale(){
+   *     // your logic here
+   *   }
+   * }
+   * }
+   * </pre>
+   * Then you should use {@code TileView.setDetailLevelManager} before other method calls, especially
+   * {@code TileView.setSize} and {@code TileView.addDetailLevel}.
+   * </p>
+   *
+   * @param manager The DetailLevelManager instance used.
+   */
+  public void setDetailLevelManager( DetailLevelManager manager ) {
+    mDetailLevelManager = manager;
+  }
+
   @Override
   protected void onLayout( boolean changed, int l, int t, int r, int b ) {
     super.onLayout( changed, l, t, r, b );

--- a/tileview/src/main/java/com/qozix/tileview/detail/DetailLevelManager.java
+++ b/tileview/src/main/java/com/qozix/tileview/detail/DetailLevelManager.java
@@ -9,11 +9,11 @@ import java.util.LinkedList;
 
 public class DetailLevelManager {
 
-  private LinkedList<DetailLevel> mDetailLevelLinkedList = new LinkedList<DetailLevel>();
+  protected LinkedList<DetailLevel> mDetailLevelLinkedList = new LinkedList<DetailLevel>();
 
   private DetailLevelChangeListener mDetailLevelChangeListener;
 
-  private float mScale = 1;
+  protected float mScale = 1;
 
   private int mBaseWidth;
   private int mBaseHeight;
@@ -127,7 +127,7 @@ public class DetailLevelManager {
     return mCurrentDetailLevel;
   }
 
-  private void update() {
+  protected void update() {
     boolean detailLevelChanged = false;
     if( !mDetailLevelLocked ) {
       DetailLevel matchingLevel = getDetailLevelForScale();


### PR DESCRIPTION
I did it in a very simple way. I changed some attibutes from `private` to `protected`, so a class that extends `DetailLevelManager` can use them. I tested in the demo with no issue.

Also, bumped version to 2.1.5