### PR TITLE
Fix #304 & OOM on zoom-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ###Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:2.1.5'
+compile 'com.qozix:tileview:2.1.6'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.
@@ -56,7 +56,7 @@ A demo application, built in Android Studio, is available in the `demo` folder o
 at the 2nd column from left and 3rd row from top.
 1. Create a new application with a single activity ('Main').
 1. Save the image tiles to your `assets` directory.
-1. Add `compile 'com.qozix:tileview:2.1.5'` to your gradle dependencies.
+1. Add `compile 'com.qozix:tileview:2.1.6'` to your gradle dependencies.
 1. In the Main Activity, use this for `onCreate`:
 ```
 @Override

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 22
-        versionCode 30
-        versionName "2.1.5"
+        versionCode 31
+        versionName "2.1.6"
     }
     buildTypes {
         release {

--- a/tileview/src/main/java/com/qozix/tileview/geom/CoordinateTranslater.java
+++ b/tileview/src/main/java/com/qozix/tileview/geom/CoordinateTranslater.java
@@ -119,9 +119,15 @@ public class CoordinateTranslater {
    * @param x The x value to be translated.
    * @return The relative value of the x coordinate supplied.
    */
+  public double translateAbsoluteToRelativeX( float x ) {
+    return mLeft + ( x * mDiffX / mWidth );
+  }
+
+  /**
+   * Pipes to {@link #translateAbsoluteToRelativeX( float )}
+   */
   public double translateAbsoluteToRelativeX( int x ) {
-    double factor = x / mWidth;
-    return mLeft + (factor * mDiffX);
+    return translateAbsoluteToRelativeX( (float) x );
   }
 
   /**
@@ -131,8 +137,15 @@ public class CoordinateTranslater {
    * @param scale The scale to apply.
    * @return The relative value of the x coordinate supplied.
    */
+  public double translateAndScaleAbsoluteToRelativeX( float x, float scale ) {
+    return translateAbsoluteToRelativeX( x / scale );
+  }
+
+  /**
+   * @see #translateAndScaleAbsoluteToRelativeX(float, float)
+   */
   public double translateAndScaleAbsoluteToRelativeX( int x, float scale ) {
-    return translateAbsoluteToRelativeX( FloatMathHelper.unscale( x, scale ) );
+    return translateAbsoluteToRelativeX( x / scale );
   }
 
   /**
@@ -141,9 +154,15 @@ public class CoordinateTranslater {
    * @param y The y value to be translated.
    * @return The relative value of the y coordinate supplied.
    */
+  public double translateAbsoluteToRelativeY( float y ) {
+    return mTop + ( y * mDiffY / mHeight );
+  }
+
+  /**
+   * Pipes to {@link #translateAbsoluteToRelativeY( float )}
+   */
   public double translateAbsoluteToRelativeY( int y ) {
-    double factor = y / mHeight;
-    return mTop + (factor * mDiffY);
+    return translateAbsoluteToRelativeY( (float) y );
   }
 
   /**
@@ -153,8 +172,15 @@ public class CoordinateTranslater {
    * @param scale The scale to apply.
    * @return The relative value of the y coordinate supplied.
    */
+  public double translateAndScaleAbsoluteToRelativeY( float y, float scale ) {
+    return translateAbsoluteToRelativeY( y / scale );
+  }
+
+  /**
+   * @see #translateAndScaleAbsoluteToRelativeY(float, float)
+   */
   public double translateAndScaleAbsoluteToRelativeY( int y, float scale ) {
-    return translateAbsoluteToRelativeY( FloatMathHelper.unscale( y, scale ) );
+    return translateAbsoluteToRelativeY( y / scale );
   }
 
   /**


### PR DESCRIPTION
Issue fixed, and added method signatures using `float` instead of `int`, actually only useful when some or all detail levels are defined for scale > 1.
To avoid breaking change, methods have been added and pipe to the `float` version ones.