### PR TITLE
Feature Request: Overridable Scrolling Limitations

### DIFF
--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -563,20 +563,28 @@ public class ZoomPanLayout extends ViewGroup implements
     return FloatMathHelper.scale( getHeight(), 0.5f );
   }
 
-  private int getConstrainedScrollX( int x ) {
-    return Math.max( 0, Math.min( x, getScrollLimitX() ) );
+  protected int getConstrainedScrollX( int x ) {
+    return Math.max( getScrollMinX(), Math.min( x, getScrollLimitX() ) );
   }
 
-  private int getConstrainedScrollY( int y ) {
-    return Math.max( 0, Math.min( y, getScrollLimitY() ) );
+  protected int getConstrainedScrollY( int y ) {
+    return Math.max( getScrollMinY(), Math.min( y, getScrollLimitY() ) );
   }
 
-  private int getScrollLimitX() {
+  protected int getScrollLimitX() {
     return mScaledWidth - getWidth();
   }
 
-  private int getScrollLimitY() {
+  protected int getScrollLimitY() {
     return mScaledHeight - getHeight();
+  }
+
+  protected int getScrollMinX(){
+    return 0;
+  }
+
+  protected int getScrollMinY(){
+    return 0;
   }
 
   @Override


### PR DESCRIPTION
This one's pretty simple and related to a common request: scrolling beyond the current sheet limits: open up the methods used to limit the scrolling to being overridden, and replace the hardcoded `0` scroll minimum with its own methods, `#getScrollMinX` and `#getScrollMinY`. 