### PR TITLE
Scroll changes - allow fling to slide off left and top; allow scroller to be replaced

### DIFF
--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -713,7 +713,9 @@ public class ZoomPanLayout extends ViewGroup implements
 
   @Override
   public boolean onFling( MotionEvent event1, MotionEvent event2, float velocityX, float velocityY ) {
-    mScroller.fling( getScrollX(), getScrollY(), (int) -velocityX, (int) -velocityY, 0, getScrollLimitX(), 0, getScrollLimitY() );
+    mScroller.fling( getScrollX(), getScrollY(), (int) -velocityX, (int) -velocityY,
+                     getScrollMinX(), getScrollLimitX(), getScrollMinY(), getScrollLimitY() );
+
     mIsFlinging = true;
     ViewCompat.postInvalidateOnAnimation( this );
     broadcastFlingBegin();

--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -589,18 +589,18 @@ public class ZoomPanLayout extends ViewGroup implements
 
   @Override
   public void computeScroll() {
-    if( mScroller.computeScrollOffset() ) {
+    if( getScroller().computeScrollOffset() ) {
       int startX = getScrollX();
       int startY = getScrollY();
-      int endX = getConstrainedScrollX( mScroller.getCurrX() );
-      int endY = getConstrainedScrollY( mScroller.getCurrY() );
+      int endX = getConstrainedScrollX( getScroller().getCurrX() );
+      int endY = getConstrainedScrollY( getScroller().getCurrY() );
       if( startX != endX || startY != endY ) {
         scrollTo( endX, endY );
         if( mIsFlinging ) {
           broadcastFlingUpdate();
         }
       }
-      if( mScroller.isFinished() ) {
+      if( getScroller().isFinished() ) {
         if( mIsFlinging ) {
           mIsFlinging = false;
           broadcastFlingEnd();
@@ -631,19 +631,19 @@ public class ZoomPanLayout extends ViewGroup implements
 
   private void broadcastFlingBegin() {
     for( ZoomPanListener listener : mZoomPanListeners ) {
-      listener.onPanBegin( mScroller.getStartX(), mScroller.getStartY(), ZoomPanListener.Origination.FLING );
+      listener.onPanBegin( getScroller().getStartX(), getScroller().getStartY(), ZoomPanListener.Origination.FLING );
     }
   }
 
   private void broadcastFlingUpdate() {
     for( ZoomPanListener listener : mZoomPanListeners ) {
-      listener.onPanUpdate( mScroller.getCurrX(), mScroller.getCurrY(), ZoomPanListener.Origination.FLING );
+      listener.onPanUpdate( getScroller().getCurrX(), getScroller().getCurrY(), ZoomPanListener.Origination.FLING );
     }
   }
 
   private void broadcastFlingEnd() {
     for( ZoomPanListener listener : mZoomPanListeners ) {
-      listener.onPanEnd( mScroller.getFinalX(), mScroller.getFinalY(), ZoomPanListener.Origination.FLING );
+      listener.onPanEnd( getScroller().getFinalX(), getScroller().getFinalY(), ZoomPanListener.Origination.FLING );
     }
   }
 
@@ -703,8 +703,8 @@ public class ZoomPanLayout extends ViewGroup implements
 
   @Override
   public boolean onDown( MotionEvent event ) {
-    if( mIsFlinging && !mScroller.isFinished() ) {
-      mScroller.forceFinished( true );
+    if( mIsFlinging && !getScroller().isFinished() ) {
+      getScroller().forceFinished( true );
       mIsFlinging = false;
       broadcastFlingEnd();
     }
@@ -713,7 +713,7 @@ public class ZoomPanLayout extends ViewGroup implements
 
   @Override
   public boolean onFling( MotionEvent event1, MotionEvent event2, float velocityX, float velocityY ) {
-    mScroller.fling( getScrollX(), getScrollY(), (int) -velocityX, (int) -velocityY,
+    getScroller().fling( getScrollX(), getScrollY(), (int) -velocityX, (int) -velocityY,
                      getScrollMinX(), getScrollLimitX(), getScrollMinY(), getScrollLimitY() );
 
     mIsFlinging = true;

--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -85,7 +85,6 @@ public class ZoomPanLayout extends ViewGroup implements
     super( context, attrs, defStyleAttr );
     setWillNotDraw( false );
     setClipChildren( false );
-    mScroller = new Scroller( context );
     mGestureDetector = new GestureDetector( context, this );
     mScaleGestureDetector = new ScaleGestureDetector( context, this );
     mTouchUpGestureDetector = new TouchUpGestureDetector( this );
@@ -317,6 +316,10 @@ public class ZoomPanLayout extends ViewGroup implements
    * @return The Scroller instance use to manage dragging and flinging.
    */
   public Scroller getScroller() {
+    // Instantiate default scroller if none is available
+    if( mScroller == null ){
+      mScroller = new Scroller( getContext() );
+    }
     return mScroller;
   }
 


### PR DESCRIPTION
This changes the logic in `ZoomPanLayout#onFling` to use `#getScrollMinX` and `#getScrollMinY` to decide how far to the left and top it will scroll instead of using hard-coded `0`.