### PR TITLE
remove the `-target 8` line from proguard-rules.pro

### DIFF
--- a/tileview/proguard-rules.pro
+++ b/tileview/proguard-rules.pro
@@ -18,5 +18,3 @@
 -keep class com.qozix** {*;}
 -keepattributes InnerClasses
 -keepattributes EnclosingMethod
-
--target 8


### PR DESCRIPTION
This should fix builds for you, @moagrius , but I can't confirm that this produces a library version that works with the desugar tool. 

I've got a [dockerfile](https://gist.github.com/MisterRager/e2af2178b8f6171aab85af0f4e2e19b5) that I cobbled together to try to run builds. I run the following command:
```
docker run -v "$(pwd):/werk" -w '/werk' -e JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64 16b601585a4b  /werk/gradlew tasks
```
But I get stuck with this error:
```
> java.lang.UnsupportedClassVersionError: com/android/build/gradle/AppPlugin : Unsupported major.minor version 52.0
```

It's also crashing with someone else's docker setup with the same error (same error):
```
docker run --tty --interactive --volume=$(pwd):/opt/workspace --workdir=/opt/workspace --rm jacekmarchwicki/android:java7  /bin/sh -c "./gradlew build"
```

If you could throw me the aar or zip release produced, I can walk through the contents with `javap` to make sure stackmap frames are present.