### PR TITLE
Fix#415

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ### Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:'2.2.6'
+compile 'com.qozix:tileview:'2.2.7'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.
@@ -64,7 +64,7 @@ A demo application, built in Android Studio, is available in the `demo` folder o
 at the 2nd column from left and 3rd row from top.
 1. Create a new application with a single activity ('Main').
 1. Save the image tiles to your `assets` directory.
-1. Add `compile 'com.qozix:tileview:2.2.6'` to your gradle dependencies.
+1. Add `compile 'com.qozix:tileview:2.2.7'` to your gradle dependencies.
 1. In the Main Activity, use this for `onCreate`:
 ```
 @Override

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 11
         targetSdkVersion 23
-        versionCode 37
-        versionName "2.2.6"
+        versionCode 38
+        versionName "2.2.7"
     }
     buildTypes {
         release {

--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -49,6 +49,8 @@ public class ZoomPanLayout extends ViewGroup implements
   private int mOffsetY;
 
   private float mEffectiveMinScale = 0;
+  private float mMinimumScaleX;
+  private float mMinimumScaleY;
   private boolean mShouldLoopScale = true;
 
   private boolean mIsFlinging;
@@ -538,9 +540,9 @@ public class ZoomPanLayout extends ViewGroup implements
   }
 
   private void calculateMinimumScaleToFit() {
-    float minimumScaleX = getWidth() / (float) mBaseWidth;
-    float minimumScaleY = getHeight() / (float) mBaseHeight;
-    float recalculatedMinScale = calculatedMinScale(minimumScaleX, minimumScaleY);
+    mMinimumScaleX = getWidth() / (float) mBaseWidth;
+    mMinimumScaleY = getHeight() / (float) mBaseHeight;
+    float recalculatedMinScale = calculatedMinScale(mMinimumScaleX, mMinimumScaleY);
     if( recalculatedMinScale != mEffectiveMinScale ) {
       mEffectiveMinScale = recalculatedMinScale;
       if( mScale < mEffectiveMinScale ){
@@ -567,10 +569,20 @@ public class ZoomPanLayout extends ViewGroup implements
   }
 
   protected int getConstrainedScrollX( int x ) {
+    if ( mMinimumScaleMode == MinimumScaleMode.FIT &&  mScale < mMinimumScaleX ) {
+      float scaleFactor = mScale / ( mMinimumScaleX - mMinimumScaleY ) +
+              mMinimumScaleY / ( mMinimumScaleY - mMinimumScaleX );
+      return (int) ( scaleFactor * getScrollX() );
+    }
     return Math.max( getScrollMinX(), Math.min( x, getScrollLimitX() ) );
   }
 
   protected int getConstrainedScrollY( int y ) {
+    if ( mMinimumScaleMode == MinimumScaleMode.FIT && mScale < mMinimumScaleY ) {
+      float scaleFactor = mScale / ( mMinimumScaleY - mMinimumScaleX ) +
+              mMinimumScaleX / ( mMinimumScaleX - mMinimumScaleY );
+      return (int) ( scaleFactor * getScrollY() );
+    }
     return Math.max( getScrollMinY(), Math.min( y, getScrollLimitY() ) );
   }
 

--- a/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
+++ b/tileview/src/main/java/com/qozix/tileview/widgets/ZoomPanLayout.java
@@ -568,19 +568,30 @@ public class ZoomPanLayout extends ViewGroup implements
     return FloatMathHelper.scale( getHeight(), 0.5f );
   }
 
+  /**
+   * When the scale is less than {@code mMinimumScaleX}, either because we are using
+   * {@link MinimumScaleMode#FIT} or {@link MinimumScaleMode#NONE}, the scroll position takes a
+   * value between its starting value and 0. A linear interpolation between the
+   * {@code mMinimumScaleX} and the {@code mEffectiveMinScale} is used. <p>
+   * This strategy is used to avoid that a custom return value of {@link #getScrollMinX} (which
+   * default to 0) become the return value of this method which shifts the whole TileView.
+   */
   protected int getConstrainedScrollX( int x ) {
-    if ( mMinimumScaleMode == MinimumScaleMode.FIT &&  mScale < mMinimumScaleX ) {
-      float scaleFactor = mScale / ( mMinimumScaleX - mMinimumScaleY ) +
-              mMinimumScaleY / ( mMinimumScaleY - mMinimumScaleX );
+    if ( mScale < mMinimumScaleX && mEffectiveMinScale != mMinimumScaleX ) {
+      float scaleFactor = mScale / ( mMinimumScaleX - mEffectiveMinScale ) +
+              mEffectiveMinScale / ( mEffectiveMinScale - mMinimumScaleX );
       return (int) ( scaleFactor * getScrollX() );
     }
     return Math.max( getScrollMinX(), Math.min( x, getScrollLimitX() ) );
   }
 
+  /**
+   * See {@link #getConstrainedScrollX(int)}
+   */
   protected int getConstrainedScrollY( int y ) {
-    if ( mMinimumScaleMode == MinimumScaleMode.FIT && mScale < mMinimumScaleY ) {
-      float scaleFactor = mScale / ( mMinimumScaleY - mMinimumScaleX ) +
-              mMinimumScaleX / ( mMinimumScaleX - mMinimumScaleY );
+    if ( mScale < mMinimumScaleY && mEffectiveMinScale != mMinimumScaleY ) {
+      float scaleFactor = mScale / ( mMinimumScaleY - mEffectiveMinScale ) +
+              mEffectiveMinScale / ( mEffectiveMinScale - mMinimumScaleY );
       return (int) ( scaleFactor * getScrollY() );
     }
     return Math.max( getScrollMinY(), Math.min( y, getScrollLimitY() ) );


### PR DESCRIPTION
Hey Mike,

I don't know if you're aware of #415 : the OP describes the problem pretty well. To summarize, when the MinimumScaleMode#FIT was introduced, the logic to calculate the constrained X/Y scroll position needed to be adapted. Well, not exactly. In fact, in most cases there is no issue. But when a developer extends the `TileView` and overrides (as he's allowed to) the `getScrollMinX` and `getScrollLimitX` to return something different than 0, then the whole TileView is shifted at minimum scale. 

Investigating on this, i found that it was not the only issue. Scrolling slowly at the boundaries of the TileView would make the scroll position change from eg -100 to 0 without any transition (which is a weird behavior). This happens when the scale is equal to `mMinimumScaleY` or `mMinimumScaleX`, depending on the shape of the tileset.

So i worked on the logic of `getConstrainedScrollX` and `getConstrainedScrollY` to work also when non zero return values are defined for `getScrollMinX`, `getScrollLimitX`, `getScrollMinY`, `getScrollLimitY`.
I came up with this implementation, which i tested and so did the author of #415.