### PR TITLE
Fix #301

### DIFF
--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
@@ -362,8 +362,11 @@ public class TileCanvasViewGroup extends ViewGroup {
   }
 
   private void beginRenderTask() {
-    // update the detail level properties considering the visible viewport
-    mDetailLevelToRender.computeCurrentState();
+    // if visible columns and rows are same as previously computed, fast-fail
+    boolean changed = mDetailLevelToRender.computeCurrentState();
+    if( !changed && mTilesInCurrentViewport.size() > 0 ) {
+      return;
+    }
     // determine tiles are mathematically within the current viewport; force re-computation
     mDetailLevelToRender.computeVisibleTilesFromViewport();
     // get rid of anything outside, use previously computed intersections

--- a/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
+++ b/tileview/src/main/java/com/qozix/tileview/tiles/TileCanvasViewGroup.java
@@ -39,8 +39,6 @@ public class TileCanvasViewGroup extends ViewGroup {
   private BitmapRecycler mBitmapRecycler;
 
   private DetailLevel mDetailLevelToRender;
-  private DetailLevel mLastRenderedDetailLevel;
-
 
   private boolean mRenderIsCancelled = false;
   private boolean mRenderIsSuppressed = false;
@@ -364,11 +362,8 @@ public class TileCanvasViewGroup extends ViewGroup {
   }
 
   private void beginRenderTask() {
-    // if visible columns and rows are same as previously computed, fast-fail
-    boolean changed = mDetailLevelToRender.computeCurrentState();
-    if( !changed && mDetailLevelToRender.equals( mLastRenderedDetailLevel ) ) {
-      return;
-    }
+    // update the detail level properties considering the visible viewport
+    mDetailLevelToRender.computeCurrentState();
     // determine tiles are mathematically within the current viewport; force re-computation
     mDetailLevelToRender.computeVisibleTilesFromViewport();
     // get rid of anything outside, use previously computed intersections
@@ -495,7 +490,6 @@ public class TileCanvasViewGroup extends ViewGroup {
       if( mTileRenderListener != null ) {
         mTileRenderListener.onRenderComplete();
       }
-      mLastRenderedDetailLevel = mDetailLevelToRender;
       requestRender();
     }
   };


### PR DESCRIPTION
This fixes the missing tiles issue i could reproduce.

There is only one change : modifying the fast-fail test in `TileCanvasViewGroup.requestRender()` and removing all boilerplate code related to `mLastRenderedDetailLevel`.

The explanation of this change is, from the tests i run,  when we have missing tiles after a quick zooming out, we can observe the following :

A high amount of request render are kicked in `TileCanvasViewGroup.requestRender()` which is based on a throttle logic. Those requests which usually pass through this enable the launch of new tile decoding with the `TileRenderPoolExecutor`, in the `beginRenderTask`. So since no new task are sent to the executor, the rendering mechanism is broken.
The addition of the `mTilesInCurrentViewport.size() > 0` in the fast-fail test enables the last request render to not fast-fail and trigger the missing render.

As for the removing of the `mLastRenderedDetailLevel`, there are two reasons :
* it was historically added before we removed the detail level lock, to fix an OOM issue. It is not needed anymore.
* it's ugly

