### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Javadocs are [here](http://moagrius.github.io/TileView/index.html?com/qozix/tile
 ### Installation
 Gradle:
 ```
-compile 'com.qozix:tileview:2.2.9'
+implementation 'com.qozix:tileview:2.2.9'
 ```
 
 The library is hosted on jcenter, and is not currently available from maven.


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.