### PR TITLE
limit zoom to minimum of 0 when computing

### DIFF
--- a/demo/src/main/java/com/moagrius/TileViewDemoAssets.java
+++ b/demo/src/main/java/com/moagrius/TileViewDemoAssets.java
@@ -12,10 +12,10 @@ public class TileViewDemoAssets extends TileViewDemoActivity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_demos_tileview);
     TileView tileView = findViewById(R.id.tileview);
+    tileView.setScaleLimits(1f, 2f);
     new TileView.Builder(tileView)
         .setSize(17934, 13452)
         .defineZoomLevel("tiles/phi-1000000-%1$d_%2$d.jpg")
-        .addReadyListener(this)
         .build();
 
   }

--- a/tileview/src/main/java/com/moagrius/tileview/TileView.java
+++ b/tileview/src/main/java/com/moagrius/tileview/TileView.java
@@ -250,6 +250,9 @@ public class TileView extends ScalingScrollView implements
     }
     int previousZoom = mZoom;
     mZoom = Detail.getZoomFromPercent(currentScale);
+    if (mZoom < 0) {
+      mZoom = 0;
+    }
     boolean zoomChanged = mZoom != previousZoom;
     if (zoomChanged) {
       mPreviouslyDrawnTiles.clear();


### PR DESCRIPTION
@peterLaurence if you don't have time or bandwidth to review this one, it's pretty straightfoward, and i was able to repro the bug, and visually experience that this fix does indeed correct it, so i can merge.  that said, another pair of eyes confirming that is always a good thing, so i'll leave it as an eligible PR for now.

also, the `setMaximumScale` needs to be in `ScalingScrollView` which is another repo now, so I'll make a PR there following this.

thanks!