### PR TITLE
Issue 511 - Save and Restore Instance State

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -13,18 +13,18 @@
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme">
-    <activity android:name=".MainActivity">
+    <activity android:name=".MainActivity" android:configChanges="orientation|screenSize">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
-    <activity android:name=".TileViewDemoInternalStorage" />
-    <activity android:name=".TileViewDemoExternalStorage" />
-    <activity android:name=".TileViewDemoHttp" />
-    <activity android:name=".TileViewDemoAssets" />
-    <activity android:name=".TileViewDemoAdvanced" />
+    <activity android:name=".TileViewDemoInternalStorage" android:configChanges="orientation|screenSize" />
+    <activity android:name=".TileViewDemoExternalStorage" android:configChanges="orientation|screenSize" />
+    <activity android:name=".TileViewDemoHttp" android:configChanges="orientation|screenSize" />
+    <activity android:name=".TileViewDemoAssets" android:configChanges="orientation|screenSize" />
+    <activity android:name=".TileViewDemoAdvanced" android:configChanges="orientation|screenSize" />
   </application>
 
 </manifest>

--- a/demo/src/main/java/com/moagrius/TileViewDemoAdvanced.java
+++ b/demo/src/main/java/com/moagrius/TileViewDemoAdvanced.java
@@ -112,8 +112,8 @@ public class TileViewDemoAdvanced extends Activity {
     };
 
     for (double[] coordinate : sites) {
-      int x = coordinatePlugin.longitudeToX(coordinate[1]);
-      int y = coordinatePlugin.latitudeToY(coordinate[0]);
+      int x = coordinatePlugin.longitudeToUnscaledX(coordinate[1]);
+      int y = coordinatePlugin.latitudeToUnscaledY(coordinate[0]);
       ImageView marker = new ImageView(this);
       marker.setTag(coordinate);
       marker.setImageResource(R.drawable.marker);

--- a/demo/src/main/java/com/moagrius/TileViewDemoAssets.java
+++ b/demo/src/main/java/com/moagrius/TileViewDemoAssets.java
@@ -14,12 +14,14 @@ public class TileViewDemoAssets extends TileViewDemoActivity {
     setContentView(R.layout.activity_demos_tileview);
     TileView tileView = findViewById(R.id.tileview);
     frameToCenterOnReady();
+
     tileView.setScaleLimits(0f, 10f);
     tileView.setMinimumScaleMode(ScalingScrollView.MinimumScaleMode.CONTAIN);
     new TileView.Builder(tileView)
         .setSize(16384, 13056)
         .defineZoomLevel("tiles/phi-1000000-%1$d_%2$d.jpg")
         .build();
+    //tileView.setScale(0.5f);
   }
 
 }

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -43,7 +43,11 @@ dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation 'com.jakewharton:disklrucache:2.0.2'
+<<<<<<< Updated upstream
   api 'com.moagrius:scrollview:1.0.6'
+=======
+  api 'com.moagrius:scrollview:1.0.9'
+>>>>>>> Stashed changes
 }
 
 publish {

--- a/tileview/build.gradle
+++ b/tileview/build.gradle
@@ -43,11 +43,8 @@ dependencies {
   implementation fileTree(dir: 'libs', include: ['*.jar'])
   implementation 'com.android.support:appcompat-v7:28.0.0'
   implementation 'com.jakewharton:disklrucache:2.0.2'
-<<<<<<< Updated upstream
-  api 'com.moagrius:scrollview:1.0.6'
-=======
   api 'com.moagrius:scrollview:1.0.9'
->>>>>>> Stashed changes
+
 }
 
 publish {

--- a/tileview/src/main/java/com/moagrius/tileview/TileView.java
+++ b/tileview/src/main/java/com/moagrius/tileview/TileView.java
@@ -239,6 +239,14 @@ public class TileView extends ScalingScrollView implements
     return mContainer;
   }
 
+  @Override
+  protected void onRestoreInstanceState(Parcelable state) {
+    ScrollScaleState sss = (ScrollScaleState) state;
+    super.onRestoreInstanceState(sss.getSuperState());
+    requestLayout();
+  }
+
+
   @SuppressWarnings("unchecked")
   public <T extends Plugin> T getPlugin(Class<T> clazz) {
     return (T) mPlugins.get(clazz);

--- a/tileview/src/main/java/com/moagrius/tileview/TileView.java
+++ b/tileview/src/main/java/com/moagrius/tileview/TileView.java
@@ -8,8 +8,6 @@ import android.graphics.Rect;
 import android.graphics.Region;
 import android.os.Handler;
 import android.os.Message;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -126,25 +124,6 @@ public class TileView extends ScalingScrollView implements
     // e.g., ViewGroup.addView(child) will call ViewGroup.addView(child, -1, ...)
     // which will end up placing the child in the TileView rather than the container
     super.addView(mContainer, -1, generateDefaultLayoutParams());
-  }
-
-  @Override
-  protected void onRestoreInstanceState(Parcelable state) {
-    TileViewState tvs = (TileViewState) state;
-    mUuid = tvs.uuid;
-    Builder builder = sPersistentBuilderMap.get(mUuid);
-    builder.build();
-    sPersistentBuilderMap.remove(mUuid);
-    super.onRestoreInstanceState(tvs.getSuperState());
-  }
-
-  @Override
-  protected Parcelable onSaveInstanceState() {
-    Parcelable superState = super.onSaveInstanceState();
-    TileViewState tvs = new TileViewState(superState);
-    tvs.uuid = mUuid;
-    sPersistentBuilderMap.put(mUuid, getBuilder());
-    return tvs;
   }
 
   @Override
@@ -838,41 +817,6 @@ public class TileView extends ScalingScrollView implements
       return null;
     }
 
-  }
-
-  protected static class TileViewState extends ScrollScaleState {
-
-    private String uuid;
-
-    public TileViewState(Parcelable superState) {
-      super(superState);
-    }
-
-    public TileViewState(Parcel source) {
-      super(source);
-      uuid = source.readString();
-    }
-
-    @Override
-    public void writeToParcel(Parcel dest, int flags) {
-      super.writeToParcel(dest, flags);
-      dest.writeString(uuid);
-    }
-
-    @Override
-    public String toString() {
-      return "TileViewState{" + Integer.toHexString(System.identityHashCode(this)) + " scrollPositionY=" + scrollPositionY + ", scrollPositionX=" + scrollPositionX + ", scale=" + scale + ", uuid=" + uuid + "}";
-    }
-
-    public static final Creator<TileViewState> CREATOR = new Creator<TileViewState>() {
-      public TileViewState createFromParcel(Parcel in) {
-        return new TileViewState(in);
-      }
-
-      public TileViewState[] newArray(int size) {
-        return new TileViewState[size];
-      }
-    };
   }
 
   public interface TileDecodeErrorListener {


### PR DESCRIPTION
@peterLaurence  So this is branched from 510.  I've spend a few days on it now and I'm not clear at all about what's failing.  Version 2 worked as expected out of the box - I suspect it's the whole builder/prepare thing, but that doesn't make a ton of sense either because onCreate is firing again so the new Builder should take precedence.  I think it might have something to do with when scale is being set that's throwing off the plugins, because I can get it right with just the tiles, it's the plugins (markers, paths, most obviously) that are breaking.

Since I'd like to get all the other fixes in a release, I've applied a simple workaround: suppress config changes in each of the demo activities.  That's obviously not a long term solution but I think does buy another week or so to figure out what's wrong with save/restore.

Note that this is branched from 510, so ideally i'd merge this into 510, then 510 into master, if it passed code review.

The whole UUID and getBuilder stuff are just artifacts.  I'll clean it up before more, but they're not being used now in any way.

Thanks as always.